### PR TITLE
Parse the leaf data and store this in a new table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ And the tile hashes at different levels inspected:
 sqlite3 ~/sum.db 'SELECT level, COUNT(*) FROM tiles GROUP BY level;'
 ```
 
+And the processed leaf data can be inspected to ensure that the same module+version does not appear twice:
+```bash
+sqlite3 ~/sum.db 'SELECT module, version, COUNT(*) cnt FROM leafMetadata GROUP BY module, version HAVING cnt > 1;'
+```
+
 ## TODO
 * This only downloads complete tiles, which means that at any point there could be up to 255 leaves missing from the database. These stragglers should be stored if the root hash checks out.
 * The verified Checkpoint should be stored locally.

--- a/cli/clone/clone.go
+++ b/cli/clone/clone.go
@@ -56,8 +56,12 @@ func main() {
 	if err := s.CheckRootHash(ctx, checkpoint); err != nil {
 		log.Fatalf("CheckRootHash: %v", err)
 	}
-	log.Printf("Cloned successfully. Tree size is %d, hash is %x (%s).", checkpoint.N, checkpoint.Hash[:], checkpoint.Hash)
+	log.Printf("Cloned successfully. Tree size is %d, hash is %x (%s). Processing data...", checkpoint.N, checkpoint.Hash[:], checkpoint.Hash)
 
+	if err := s.ProcessMetadata(ctx, checkpoint); err != nil {
+		log.Fatalf("ProcessMetadata: %v", err)
+	}
+	log.Printf("Leaf data processed.")
 	if *extraV {
 		log.Printf("Performing extra validation on tiles...")
 		if err := s.VerifyTiles(ctx, checkpoint); err != nil {


### PR DESCRIPTION
This allows querying for duplicates. An example query has been added to the docs.

Also fixed a few runaways in the database which were logging instead of returning errors.